### PR TITLE
Fix License inconsistency

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "detect-node-es",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Detect Node.JS (as opposite to browser environment). ESM modification",
   "main": "es5/node.js",
   "module": "esm/node.js",
@@ -21,7 +21,7 @@
     "node"
   ],
   "author": "Ilya Kantor",
-  "license": "ISC",
+  "license": "MIT",
   "bugs": {
     "url": "https://github.com/thekashey/detect-node/issues"
   },


### PR DESCRIPTION
[iliakan/detect-node](https://github.com/iliakan/detect-node) and [LICENSE](https://github.com/theKashey/detect-node/blob/084d6d69cb29e3971ed3fa27dad037d836acfab0/LICENSE) it says it is licensed under MIT. However, the [package.json](https://github.com/theKashey/detect-node/blob/084d6d69cb29e3971ed3fa27dad037d836acfab0/package.json) still has another identifier. This PR resolves the issue.
- Backport of iliakan/detect-node#16
- Updates the package.json to be consistent with iliakan/detect-node
- Replace ISC with MIT as stated in LICENSE and iliakan/detect-node#9